### PR TITLE
Implement options cache write-protection logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,6 +426,8 @@ Version: v2.8.0</div>
     <div class="input-group"><label class="input-label">Font Size</label><select class="input" id="font-size-input"><option value="15">Small (15px)</option><option value="17">Medium (17px)</option><option value="19" selected>Default (19px)</option><option value="21">Large (21px)</option><option value="23">Extra Large (23px)</option><option value="26">2XL (26px)</option><option value="30">3XL (30px)</option><option value="36">4XL (36px)</option></select></div>
     <div class="input-group"><label class="input-label">Timestamp Display</label><select class="input" id="tz-pref-input"><option value="PT">Pacific Time (PT) -- home timezone</option><option value="local">Local Device Time</option><option value="UTC">UTC / GMT</option></select></div>
     <div style="font-family:var(--mono);font-size:10px;color:var(--text3);margin-bottom:12px;line-height:1.6">All timestamps throughout the app will use this timezone. Relative age (e.g. "3h ago") is always shown alongside.</div>
+    <div class="input-group"><label class="input-label">Options cache write cutoff</label><select class="input" id="options-cutoff-input"></select></div>
+    <div style="font-family:var(--mono);font-size:10px;color:var(--text3);margin-bottom:12px;line-height:1.6">After this time, existing same-day options cache is preserved rather than overwritten with potentially synthetic after-hours data. Default: 6:00 PM ET.</div>
     <div class="input-group" style="display:flex;align-items:center;justify-content:space-between">
       <label class="input-label" style="margin-bottom:0">Offline Mode (skip all network fetches, serve from cache only)</label>
       <input type="checkbox" id="offline-mode-input" style="width:20px;height:20px;accent-color:var(--accent3)">
@@ -986,7 +988,8 @@ let tzPref=S.get('tz_pref')||'PT';
 let offlineMode=S.get('offline_mode')==='true';
 let fontSize=S.get('font_size')||'19';
 applyFontSize(fontSize);
-let watchlistSort=S.get('watchlist_sort')||'manual'; // manual | alpha | opportunity
+let watchlistSort=S.get('watchlist_sort')||'manual';
+if(!S.get('options_cutoff_et'))S.set('options_cutoff_et','18'); // default 6pm ET // manual | alpha | opportunity
 
 const DEFAULT_WATCHLIST=['NVDA','AMZN','GOOGL','GLW','MS','PANW','NET','NFLX','SHOP','ORCL','TSLA'];
 const WORKER_URL='https://wheel.kevinjeu.workers.dev';

--- a/js/options.js
+++ b/js/options.js
@@ -33,6 +33,45 @@ function _validateOptionsData(data){
   return{valid:true,reason:'ok'};
 }
 
+// ── Options cache write-protection window ────────────────────────────────────
+// Returns true if the current ET time is within the live options window
+// (market open 9:30am ET through the user-configured cutoff hour, default 6pm ET).
+// Outside this window, existing same-day good cache is preserved.
+function _isOptionsLiveWindow(){
+  try{
+    const cutoffHourET=parseInt(S.get('options_cutoff_et')||'18');
+    const now=new Date();
+    const etFmt=new Intl.DateTimeFormat('en-US',{
+      timeZone:'America/New_York',
+      hour:'numeric',minute:'numeric',hour12:false
+    });
+    const parts=etFmt.formatToParts(now);
+    const etHour=parseInt(parts.find(p=>p.type==='hour').value);
+    const etMin=parseInt(parts.find(p=>p.type==='minute').value);
+    const etMins=etHour*60+etMin;
+    const openMins=9*60+30;   // 9:30am ET
+    const cutoffMins=cutoffHourET*60; // e.g. 18:00 ET
+    return etMins>=openMins&&etMins<cutoffMins;
+  }catch{return true;} // default to allowing write on error
+}
+
+// Returns true if the existing cached options were written during today's live window
+function _hasGoodSameDayCache(cacheKey){
+  const existing=S.get(cacheKey);
+  if(!existing||existing.synthetic)return false;
+  const ts=existing.ts;
+  if(!ts)return false;
+  try{
+    const written=new Date(String(ts).replace(/ PT$| UTC$| local$/,'').trim());
+    if(isNaN(written.getTime()))return false;
+    // Check if written timestamp is from today (ET calendar date)
+    const todayET=new Date().toLocaleDateString('en-US',{timeZone:'America/New_York'});
+    const writtenET=written.toLocaleDateString('en-US',{timeZone:'America/New_York'});
+    return todayET===writtenET;
+  }catch{return false;}
+}
+
+
 // Options tab: load, build table, OI chart.
 // Globals used: currentTicker, currentMode, selectedExpirations, currentOptionsData, WORKER_URL, S
 // Dependencies: helpers.js, api.js, storage.js
@@ -112,17 +151,25 @@ async function loadOptionsForTicker(){
   try{
     let data,isLive=true,fetchTs=nowPT();
     try{data=await yahooOptionsViaProxy(t);
-      // Validate before caching -- reject synthetic/after-hours data
-      const _optVal=_validateOptionsData(data);
-      if(_optVal.valid){
-        S.set('options_'+t,{data:slimOptionsData(data),ts:fetchTs});
-      }else if(!S.get('options_'+t)){
-        // No prior cache exists -- save anyway with a warning flag
-        console.warn(t+': options data quality issue ('+_optVal.reason+'), saving as only available data');
-        S.set('options_'+t,{data:slimOptionsData(data),ts:fetchTs,synthetic:true});
+      // Time-window guard: outside live window (9:30am-cutoff ET),
+      // preserve any same-day good cache rather than overwriting with
+      // potentially synthetic after-hours data.
+      const _inWindow=_isOptionsLiveWindow();
+      const _hasSameDay=_hasGoodSameDayCache('options_'+t);
+      if(!_inWindow&&_hasSameDay){
+        console.log(t+': outside live window, preserving same-day options cache');
+        data=S.get('options_'+t).data;
       }else{
-        console.warn(t+': rejecting new options fetch ('+_optVal.reason+'), preserving existing cache');
-        data=S.get('options_'+t).data; // use existing good data for this session
+        const _optVal=_validateOptionsData(data);
+        if(_optVal.valid){
+          S.set('options_'+t,{data:slimOptionsData(data),ts:fetchTs});
+        }else if(!S.get('options_'+t)){
+          console.warn(t+': options data quality issue ('+_optVal.reason+'), saving as only available data');
+          S.set('options_'+t,{data:slimOptionsData(data),ts:fetchTs,synthetic:true});
+        }else{
+          console.warn(t+': rejecting new options fetch ('+_optVal.reason+'), preserving existing cache');
+          data=S.get('options_'+t).data;
+        }
       }}
     catch{const cached=S.get('options_'+t);if(cached){data=cached.data;isLive=false;fetchTs=cached.ts;showOfflineBanner(cached.ts);}else throw new Error('No options data available');}
     currentOptionsData=data;
@@ -154,17 +201,23 @@ async function loadOptionsForTicker(){
           return sum+(o.puts||[]).reduce((s,p)=>s+(p.openInterest||0),0)
                    +(o.calls||[]).reduce((s,c)=>s+(c.openInterest||0),0);
         },0);
-        const _expVal=_validateOptionsData(ed);
-        if(_expVal.valid){
-          S.set('options_exp_'+t+'_'+pair.date,ed);
+        const _expKey='options_exp_'+t+'_'+pair.date;
+        const _expInWindow=_isOptionsLiveWindow();
+        const _expHasSameDay=_hasGoodSameDayCache(_expKey);
+        if(!_expInWindow&&_expHasSameDay){
+          console.log(t+' '+pair.date+': outside live window, preserving same-day exp cache');
         }else{
-          const existing=S.get('options_exp_'+t+'_'+pair.date);
-          const existingValid=existing&&!existing.synthetic;
-          if(!existingValid){
-            console.warn(t+' '+pair.date+': saving synthetic options ('+_expVal.reason+') -- no prior good cache');
-            S.set('options_exp_'+t+'_'+pair.date,{...ed,synthetic:true});
+          const _expVal=_validateOptionsData(ed);
+          if(_expVal.valid){
+            S.set(_expKey,ed);
           }else{
-            console.warn(t+' '+pair.date+': rejecting synthetic options ('+_expVal.reason+'), preserving cache');
+            const existingValid=S.get(_expKey)&&!S.get(_expKey)?.synthetic;
+            if(!existingValid){
+              console.warn(t+' '+pair.date+': saving synthetic options ('+_expVal.reason+') -- no prior good cache');
+              S.set(_expKey,{...ed,synthetic:true});
+            }else{
+              console.warn(t+' '+pair.date+': rejecting synthetic options ('+_expVal.reason+'), preserving cache');
+            }
           }
         }
       }catch(e){

--- a/js/prefetch.js
+++ b/js/prefetch.js
@@ -27,14 +27,20 @@ async function prefetchAll(){
     try{const h1=await yahooHistory(t,'1y','1d');S.set('hist1y_'+t,{timestamps:h1.timestamps.map(d=>Math.floor(d.getTime()/1000)),closes:h1.closes.map(v=>v!=null?Math.round(v*100)/100:null),volumes:h1.volumes.map(v=>v||0),ts:nowPT()});}catch{}
     try{const opts=await yahooOptionsViaProxy(t);
       // Validate before caching -- reject synthetic/after-hours data
-      const _pv=_validateOptionsData(opts);
-      if(_pv.valid){
-        S.set('options_'+t,{data:slimOptionsData(opts),ts:nowPT()});
-      }else if(!S.get('options_'+t)){
-        console.warn(t+': prefetch options quality issue ('+_pv.reason+'), saving as only available data');
-        S.set('options_'+t,{data:slimOptionsData(opts),ts:nowPT(),synthetic:true});
+      const _pInWindow=_isOptionsLiveWindow();
+      const _pHasSameDay=_hasGoodSameDayCache('options_'+t);
+      if(!_pInWindow&&_pHasSameDay){
+        console.log(t+': prefetch outside live window, preserving same-day options cache');
       }else{
-        console.warn(t+': prefetch rejecting options ('+_pv.reason+'), preserving existing cache');
+        const _pv=_validateOptionsData(opts);
+        if(_pv.valid){
+          S.set('options_'+t,{data:slimOptionsData(opts),ts:nowPT()});
+        }else if(!S.get('options_'+t)){
+          console.warn(t+': prefetch options quality issue ('+_pv.reason+'), saving as only available data');
+          S.set('options_'+t,{data:slimOptionsData(opts),ts:nowPT(),synthetic:true});
+        }else{
+          console.warn(t+': prefetch rejecting options ('+_pv.reason+'), preserving existing cache');
+        }
       }
       const _savedOpts=S.get('options_'+t);
       if(_savedOpts){
@@ -46,14 +52,21 @@ async function prefetchAll(){
         for(const pair of monthlyPairs2){
           try{
             const expData=await yahooOptionsViaProxy(t,String(pair.ts));
-            const _ev=_validateOptionsData(expData);
-            if(_ev.valid){
-              S.set('options_exp_'+t+'_'+pair.date,expData);
-            }else if(!S.get('options_exp_'+t+'_'+pair.date)){
-              console.warn(t+' '+pair.date+': prefetch exp options synthetic ('+_ev.reason+'), saving as fallback');
-              S.set('options_exp_'+t+'_'+pair.date,{...expData,synthetic:true});
+            const _pExpKey='options_exp_'+t+'_'+pair.date;
+            const _pExpInWindow=_isOptionsLiveWindow();
+            const _pExpHasSameDay=_hasGoodSameDayCache(_pExpKey);
+            if(!_pExpInWindow&&_pExpHasSameDay){
+              console.log(t+' '+pair.date+': prefetch outside live window, preserving same-day exp cache');
             }else{
-              console.warn(t+' '+pair.date+': prefetch exp rejected ('+_ev.reason+'), preserving cache');
+              const _ev=_validateOptionsData(expData);
+              if(_ev.valid){
+                S.set(_pExpKey,expData);
+              }else if(!S.get(_pExpKey)){
+                console.warn(t+' '+pair.date+': prefetch exp options synthetic ('+_ev.reason+'), saving as fallback');
+                S.set(_pExpKey,{...expData,synthetic:true});
+              }else{
+                console.warn(t+' '+pair.date+': prefetch exp rejected ('+_ev.reason+'), preserving cache');
+              }
             }
           }catch{}
         }

--- a/js/settings.js
+++ b/js/settings.js
@@ -188,6 +188,7 @@ async function measureStorage(){
   const el=document.getElementById('storage-display');
   if(!el)return;
   el.textContent='Measuring...';
+  // Get quota via Storage API
   let usedMB='?',quotaMB='?',pct=0;
   try{
     const est=await navigator.storage.estimate();
@@ -195,6 +196,7 @@ async function measureStorage(){
     quotaMB=(est.quota/1048576).toFixed(0);
     pct=Math.round(est.usage/est.quota*100);
   }catch{}
+  // Break down by category + key count
   const cats={options:0,history:0,snap:0,news:0,other:0};
   const keyCounts={options:0,history:0,snap:0,news:0,other:0};
   for(let i=0;i<localStorage.length;i++){
@@ -226,6 +228,7 @@ async function workerHealthCheck(){
   el.textContent='Testing Worker...';
   const t0=Date.now();
   try{
+    // Ping the Worker with a lightweight quote request for a well-known ticker
     const r=await fetch(WORKER_URL+'/?ticker=SPY&type=quote',{signal:AbortSignal.timeout(8000)});
     const latency=Date.now()-t0;
     if(!r.ok){el.innerHTML='<span style="color:var(--red)">Worker returned HTTP '+r.status+' ('+latency+'ms)</span>';return;}
@@ -245,6 +248,34 @@ async function workerHealthCheck(){
   }
 }
 
+// Populate the options cache cutoff dropdown with hours 1pm-11pm ET
+// expressed in the currently selected timezone.
+function _populateCutoffSelect(){
+  const sel=document.getElementById('options-cutoff-input');
+  if(!sel)return;
+  const savedET=parseInt(S.get('options_cutoff_et')||'18');
+  // ET hours 13-23 (1pm-11pm)
+  const etHours=Array.from({length:11},(_,i)=>i+13);
+  // Compute offset from ET to display timezone
+  // ET = America/New_York; get current offset difference
+  function etToDisplay(etHour){
+    // Create a date with that ET hour today
+    const now=new Date();
+    const etStr=now.toLocaleDateString('en-US',{timeZone:'America/New_York'});
+    const [m,d,y]=etStr.split('/');
+    const pad=n=>String(n).padStart(2,'0');
+    // Build ISO string in ET
+    const etDate=new Date(`${y}-${pad(m)}-${pad(d)}T${pad(etHour)}:00:00`);
+    // Get display in selected timezone
+    const tz=document.getElementById('tz-pref-input')?.value||tzPref||'PT';
+    const tzName=tz==='PT'?'America/Los_Angeles':tz==='UTC'?'UTC':Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const label=etDate.toLocaleTimeString('en-US',{timeZone:tzName,hour:'numeric',minute:'2-digit',hour12:true});
+    const tzLabel=tz==='PT'?'PT':tz==='UTC'?'UTC':'local';
+    return label+' '+tzLabel;
+  }
+  sel.innerHTML=etHours.map(h=>`<option value="${h}"${h===savedET?' selected':''}>${etToDisplay(h)}</option>`).join('');
+}
+
 function openSettings(){
   document.getElementById('finnhub-key-input').value=FINNHUB_KEY;
   document.getElementById('default-watchlist-input').value=watchlist.join(',');
@@ -253,6 +284,7 @@ function openSettings(){
   document.getElementById('offline-mode-input').checked=offlineMode;
   document.getElementById('font-size-input').value=fontSize;
   loadWeightSliders();
+  _populateCutoffSelect();
   document.getElementById('settings-overlay').classList.add('open');
 }
 
@@ -269,21 +301,27 @@ function saveSettings(){
   S.set('vix_threshold',String(vixThreshold));
   tzPref=document.getElementById('tz-pref-input').value;
   S.set('tz_pref',tzPref);
+  const cutoffET=parseInt(document.getElementById('options-cutoff-input')?.value)||18;
+  S.set('options_cutoff_et',String(cutoffET));
   offlineMode=document.getElementById('offline-mode-input').checked;
   S.set('offline_mode',String(offlineMode));
   updateOfflineModeBar();
   fontSize=document.getElementById('font-size-input').value||'19';
   S.set('font_size',fontSize);
   applyFontSize(fontSize);
+  // Re-populate cutoff select so labels reflect new timezone
+  _populateCutoffSelect();
   const cv=S.get('vix_hist');
   if(cv?.closes){const c=cv.closes.filter(x=>x!==null);if(c.length)updateVIXIndicator(c[c.length-1]);}
   closeSettings();
   renderWatchlist();
   populateSelects();
+  // Restore selected ticker in dropdowns after rebuilding option elements
   if(currentTicker){
     document.getElementById('ticker-select').value=currentTicker;
     document.getElementById('options-ticker-select').value=currentTicker;
   }
+  // Immediately re-format all timestamp chips in the newly selected timezone
   refreshTsChipAges();
   toast('Settings saved');
 }

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // Version bump this string to force a refresh
 // of the cache when you deploy a new version.
 // ============================================
-const CACHE_NAME = 'putseller-v27';
+const CACHE_NAME = 'putseller-v28';
 
 // Files to cache on install — the app shell
 const APP_SHELL = [


### PR DESCRIPTION
Five files, SW v28. Here's how the full system works now: _isOptionsLiveWindow() — reads the stored ET cutoff hour (default 18 = 6pm ET), computes current ET time, and returns true only if we're between 9:30am and the cutoff. Used by both options.js and prefetch.js before every cache write. _hasGoodSameDayCache(key) — checks if the existing cached data was written today (ET calendar date) and is not flagged as synthetic. If yes, it's worth protecting. Write-protection logic in both options.js and prefetch.js:

Inside live window → validate and write normally
Outside live window + good same-day cache exists → skip write, log it, use existing cache Outside live window + no good cache → fall through to validation (better something than nothing)

Settings UI — a new "Options cache write cutoff" dropdown appears below the timezone selector. Labels are displayed in your selected timezone (e.g. "3:00 PM PT" for 6pm ET when in PT), and update automatically when you change the timezone preference. Stored internally as an ET hour integer so the market-hours logic is always correct regardless of display timezone. Default 6pm ET (18).