### PR TITLE
Add ETF research sandbox functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@ a{color:inherit}
     <div class="header-title">PutSeller Pro <span id="header-status-dot" title="Data freshness" style="display:inline-block;width:8px;height:8px;border-radius:50%;background:#555870;margin-left:4px;vertical-align:middle"></span></div>
     <div class="header-sub">
       <span class="online-dot online-dot-on" id="online-dot"></span>
-      <span>Options Income Strategy v2.9.0</span>
+      <span>Options Income Strategy v3.0.0</span>
     </div>
     <div id="vix-status-banner"></div>
   </div>
@@ -336,6 +336,17 @@ a{color:inherit}
 <div id="tab-etf" class="tab-panel">
   <div class="card"><div class="card-title"><span class="dot" style="background:var(--accent2)"></span>Options Income ETFs</div><div style="font-family:var(--mono);font-size:11px;color:var(--text3);margin-bottom:10px">SPYI (covered calls on S&amp;P 500) and NBOS (put-writing strategy). Monthly distributions tracked.</div><button class="btn btn-secondary" onclick="loadETFTab()">Refresh ETF Data</button></div>
   <div id="etf-content"><div class="empty"><div class="empty-icon">&#x1F4B0;</div>Press Refresh to load ETF data</div></div>
+
+  <!-- ETF RESEARCH SANDBOX -->
+  <div style="margin-top:16px">
+    <div style="font-family:var(--mono);font-size:10px;color:var(--text3);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:4px">&#x1F9EA; ETF Research Sandbox</div>
+    <div style="font-family:var(--mono);font-size:10px;color:var(--text3);margin-bottom:10px;line-height:1.5">Analyze any ETF for comparison with SPYI and NBOS. Sandbox data is never included in income calculations. Up to 5 ETFs.</div>
+    <div style="display:flex;gap:8px;margin-bottom:12px">
+      <input id="sb-input" class="input" type="text" placeholder="e.g. GPIQ, YMAX, JEPI" style="flex:1;text-transform:uppercase" oninput="this.value=this.value.toUpperCase()">
+      <button class="btn btn-secondary" onclick="sbAnalyze()" style="white-space:nowrap">Analyze ETF</button>
+    </div>
+    <div id="sb-tiles"></div>
+  </div>
 </div>
 
 <!-- MARKET TAB -->
@@ -407,7 +418,7 @@ VIX backwardation (VIX above VIX3M): historically strong time to sell puts</div>
 
 Offline: all data cached to localStorage -- full functionality after first prefetch
 Worker: configured in Settings (Cloudflare Worker proxy for Yahoo Finance)
-Version: v2.9.0</div>
+Version: v3.0.0</div>
   </div>
 </div>
 
@@ -628,6 +639,9 @@ Version: v2.9.0</div>
     <hr class="divider">
     <div class="card-title" style="margin-bottom:10px"><span class="dot" style="background:var(--accent3)"></span>Release Notes</div>
     <div class="commentary" style="font-size:12px;max-height:400px;overflow-y:auto">
+v3.0.0 -- 2026-05-23
+- ETF Research Sandbox: new section at the bottom of the ETF tab for ad-hoc ETF analysis. Enter any ticker (e.g. GPIQ, YMAX, JEPI) and tap Analyze ETF to generate the same tile shown for SPYI and NBOS — trailing 12-month yield, price return, total return, distribution history, and 6-month price chart. Supports up to 5 concurrent sandbox ETFs. Each sandbox ticker can be individually removed. Sandbox data is completely isolated from income calculations. Ticker list and cached data persist across sessions.
+
 v2.9.0 -- 2026-05-17
 - Relative Performance vs S&P 500 chart: new dedicated card on ticker page showing stock vs ^GSPC normalized to 100 at start of 2-year window. Teal line = ticker, gray dashed = S&P 500. Toggle earnings vertical lines (amber) on/off -- defaults to on when earnings history is available.
 - 2-year price history: all watchlist tickers now fetch 2Y daily OHLCV alongside existing 6M and 1Y history. Powers the relative performance chart and improves MA200 accuracy across the full 1Y chart period.
@@ -1098,4 +1112,3 @@ if('serviceWorker'in navigator){window.addEventListener('load',()=>{navigator.se
 
 </body>
 </html>
-        

--- a/js/etf.js
+++ b/js/etf.js
@@ -237,3 +237,254 @@ function restoreETFFromCache(){
     },150);
   }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ETF RESEARCH SANDBOX
+// Analyze up to 5 ad-hoc ETF tickers for comparison with SPYI/NBOS.
+// Completely isolated from income calculations.
+// Storage keys: etf_research_tickers (array), etf_research_TICKER (per-ticker cache)
+// ═══════════════════════════════════════════════════════════════════════════
+
+const _SB_MAX=5;
+const _SB_KEY='etf_research_tickers';
+const _SB_COLOR='#4fc3f7'; // sandbox accent color
+
+function _sbTickers(){return S.get(_SB_KEY)||[];}
+function _sbSave(arr){S.set(_SB_KEY,arr);}
+
+// ── Fetch ─────────────────────────────────────────────────────────────────
+
+async function _sbFetch(ticker){
+  let snap=null,hist6mo=null,distributions=[],trailingYield=null;
+
+  try{
+    const[quote,metrics]=await Promise.all([
+      fh(`/quote?symbol=${ticker}`),
+      fh(`/stock/metric?symbol=${ticker}&metric=all`)
+    ]);
+    snap={ticker,price:quote.c,change:quote.c-quote.pc,
+      changePct:((quote.c-quote.pc)/quote.pc*100),
+      week52High:metrics.metric?.['52WeekHigh']||null,
+      week52Low:metrics.metric?.['52WeekLow']||null,
+      dividendYield:metrics.metric?.dividendYieldIndicatedAnnual||null,
+      ts:nowPT()};
+  }catch{
+    const c=S.get('etf_research_'+ticker);
+    if(c?.snap)snap=c.snap;
+  }
+
+  try{
+    hist6mo=await yahooHistory(ticker,'1y','1d');
+  }catch{
+    const c=S.get('etf_research_'+ticker);
+    if(c?.hist)hist6mo={timestamps:c.hist.timestamps.map(d=>new Date(d)),closes:c.hist.closes};
+  }
+
+  try{
+    const r=await fetch(`${WORKER_URL}/?ticker=${encodeURIComponent(ticker)}&type=dividends&range=3y`);
+    if(r.ok){
+      const j=await r.json();
+      const ev=j.chart?.result?.[0]?.events?.dividends;
+      if(ev){
+        const divList=Object.values(ev).sort((a,b)=>b.date-a.date).slice(0,24)
+          .map(d=>({date:new Date(d.date*1000).toISOString().split('T')[0],amount:d.amount}));
+        distributions=divList;
+        const total=divList.slice(0,12).reduce((s,d)=>s+(d.amount||0),0);
+        if(snap?.price&&total>0)trailingYield=(total/snap.price*100).toFixed(2);
+      }
+    }
+    if(!distributions.length)throw new Error('no div');
+  }catch{
+    const c=S.get('etf_research_'+ticker);
+    if(c?.distributions){
+      distributions=c.distributions;
+      const total=distributions.slice(0,12).reduce((s,d)=>s+(d.amount||0),0);
+      if(snap?.price&&total>0)trailingYield=(total/snap.price*100).toFixed(2);
+    }
+  }
+
+  // Persist cache
+  S.set('etf_research_'+ticker,{
+    snap,
+    hist:hist6mo?{timestamps:hist6mo.timestamps.map(d=>d instanceof Date?d.toISOString():d),closes:hist6mo.closes}:null,
+    distributions,trailingYield,ts:nowPT()
+  });
+
+  return{snap,hist6mo,distributions,trailingYield};
+}
+
+// ── Tile HTML builder ─────────────────────────────────────────────────────
+
+function _sbBuildTile(ticker,snap,hist6mo,distributions,trailingYield,isLive){
+  const color=_SB_COLOR;
+  const chgColor=snap?(snap.change>=0?'var(--green)':'var(--red)'):'var(--text2)';
+  const chgSign=snap?(snap.change>=0?'+':''):'';
+
+  const chartLabels=hist6mo?hist6mo.timestamps.slice(-126).map(d=>{
+    if(!(d instanceof Date))d=new Date(d);
+    return d.toLocaleDateString('en-US',{month:'short',day:'numeric'});
+  }):[];
+  const chartData=hist6mo?hist6mo.closes.slice(-126):[];
+
+  let totalReturnData=[];
+  if(hist6mo&&distributions.length){
+    let cum=0;const byDate={};
+    distributions.forEach(d=>{if(d.date&&d.amount)byDate[d.date]=(byDate[d.date]||0)+d.amount;});
+    totalReturnData=hist6mo.timestamps.slice(-126).map((ts,i)=>{
+      if(!(ts instanceof Date))ts=new Date(ts);
+      const ds=ts.toISOString().split('T')[0];
+      if(byDate[ds])cum+=byDate[ds];
+      return chartData[i]!=null?chartData[i]+cum:null;
+    });
+  }
+
+  const fp=chartData.find(p=>p!=null),lp=[...chartData].reverse().find(p=>p!=null);
+  const priceRetPct=fp&&lp?((lp-fp)/fp*100):null;
+  const ft=totalReturnData.find(p=>p!=null),lt=[...totalReturnData].reverse().find(p=>p!=null);
+  const totalRetPct=ft&&lt?((lt-ft)/ft*100):null;
+
+  // Store for chart render
+  if(!window._sbChartData)window._sbChartData={};
+  window._sbChartData[ticker]={color,labels:chartLabels,data:chartData,totalReturn:totalReturnData};
+
+  return `<div class="card" id="sb-tile-${ticker}" style="border-left:4px solid ${color};margin-bottom:10px">
+    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px">
+      <div style="font-family:var(--mono);font-size:9px;background:rgba(79,195,247,0.12);color:${color};padding:2px 8px;border-radius:4px;text-transform:uppercase;letter-spacing:0.5px">&#x1F9EA; Research Sandbox — not included in income calculations</div>
+      <button onclick="sbRemove('${ticker}')" style="background:none;border:none;color:var(--text3);font-size:18px;cursor:pointer;line-height:1;padding:2px 6px">&times;</button>
+    </div>
+    <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:10px">
+      <div>
+        <div style="font-family:var(--sans);font-size:20px;font-weight:700;color:${color}">${ticker}</div>
+        <div style="font-family:var(--mono);font-size:10px;color:var(--text3);margin-top:2px">Ad-hoc ETF analysis</div>
+      </div>
+      <div style="text-align:right">
+        ${snap?`<div style="font-family:var(--mono);font-size:18px;font-weight:500">$${snap.price.toFixed(2)}</div>
+        <div style="font-family:var(--mono);font-size:11px;color:${chgColor}">${chgSign}${snap.change?.toFixed(2)} (${chgSign}${snap.changePct?.toFixed(2)}%)</div>`
+        :'<div style="font-family:var(--mono);color:var(--text3)">No price data</div>'}
+      </div>
+    </div>
+    ${tsChip(snap?.ts||'',isLive)}
+    <div class="metrics-grid" style="margin-bottom:10px">
+      <div class="metric-tile" style="grid-column:span 2">
+        <div class="metric-label">Trailing 12-Month Distribution Yield</div>
+        <div class="metric-value" style="color:${color};font-size:20px">${trailingYield?trailingYield+'%':'N/A'}</div>
+        <div class="metric-sub">${trailingYield?`Sum of last ${Math.min(12,distributions.length)} distributions / current price`:'No distribution data available'}</div>
+      </div>
+      <div class="metric-tile">
+        ${priceRetPct!=null?`<div class="metric-label">Price Return (6M)</div>
+        <div class="metric-value" style="color:${priceRetPct>=0?'var(--green)':'var(--red)'}">${priceRetPct>=0?'+':''}${priceRetPct.toFixed(1)}%</div>
+        <div class="metric-sub">NAV change only</div>`:''}
+      </div>
+      <div class="metric-tile">
+        ${totalRetPct!=null?`<div class="metric-label">Total Return (6M)</div>
+        <div class="metric-value" style="color:${totalRetPct>=0?'var(--green)':'var(--red)'}">${totalRetPct>=0?'+':''}${totalRetPct.toFixed(1)}%</div>
+        <div class="metric-sub">Price + distributions reinvested</div>`:''}
+      </div>
+      <div class="metric-tile">
+        <div class="metric-label">Annualized Yield (indicated)</div>
+        <div class="metric-value" style="font-size:13px">${snap?.dividendYield?snap.dividendYield.toFixed(2)+'%':'N/A'}</div>
+      </div>
+      <div class="metric-tile">
+        <div class="metric-label">52W High / Low</div>
+        <div class="metric-value" style="font-size:11px">$${snap?.week52High?.toFixed(2)||'N/A'} / $${snap?.week52Low?.toFixed(2)||'N/A'}</div>
+      </div>
+    </div>
+    ${distributions.length
+      ?`<div style="margin-bottom:10px">
+          <div style="font-family:var(--mono);font-size:10px;color:var(--text3);margin-bottom:6px">Recent Distributions</div>
+          ${distributions.slice(0,6).map(d=>`<div style="display:flex;justify-content:space-between;font-family:var(--mono);font-size:11px;padding:4px 0;border-bottom:1px solid var(--border)"><span style="color:var(--text2)">${d.date}</span><span style="color:${color}">$${d.amount?.toFixed(4)||'N/A'}</span></div>`).join('')}
+        </div>`
+      :'<div style="font-family:var(--mono);font-size:11px;color:var(--text3);margin-bottom:10px">No distribution history from data provider.</div>'}
+    ${chartLabels.length
+      ?`<div class="card-title" style="margin-bottom:6px"><span class="dot" style="background:${color}"></span>6-Month Price</div>
+        <div class="chart-wrap" style="height:140px"><canvas id="sb-chart-${ticker}"></canvas></div>`
+      :''}
+  </div>`;
+}
+
+function _sbRenderChart(ticker){
+  const d=window._sbChartData?.[ticker];
+  if(!d||!d.labels.length)return;
+  const ctx=document.getElementById('sb-chart-'+ticker)?.getContext('2d');
+  if(!ctx)return;
+  if(!window._sbCharts)window._sbCharts={};
+  if(window._sbCharts[ticker])window._sbCharts[ticker].destroy();
+  const datasets=[{label:'Price',data:d.data,borderColor:d.color,borderWidth:1.5,pointRadius:0,tension:0.2,fill:false}];
+  if(d.totalReturn.length)datasets.push({label:'Total Return',data:d.totalReturn,borderColor:'#ffd32a',borderWidth:1.5,pointRadius:0,tension:0.2,fill:false,borderDash:[4,3]});
+  window._sbCharts[ticker]=new Chart(ctx,{
+    type:'line',data:{labels:d.labels,datasets},
+    options:{responsive:true,maintainAspectRatio:false,
+      plugins:{legend:{display:datasets.length>1,labels:{color:'#8b8fa8',font:{size:9},boxWidth:20}}},
+      scales:{x:{ticks:{color:'#555870',font:{size:9},maxTicksLimit:6},grid:{color:'#2a2e38'}},
+              y:{ticks:{color:'#555870',font:{size:9}},grid:{color:'#2a2e38'}}}}
+  });
+}
+
+// ── Public actions ────────────────────────────────────────────────────────
+
+async function sbAnalyze(){
+  const input=document.getElementById('sb-input');
+  const ticker=(input?.value||'').trim().toUpperCase().replace(/[^A-Z0-9]/g,'');
+  if(!ticker){toast('Enter a ticker symbol');return;}
+
+  const tickers=_sbTickers();
+  if(tickers.includes(ticker)){toast(ticker+' is already in the sandbox');return;}
+  if(tickers.length>=_SB_MAX){toast('Sandbox limit is '+_SB_MAX+' ETFs — remove one first',3000);return;}
+
+  // Persist ticker immediately so it survives a crash
+  tickers.push(ticker);
+  _sbSave(tickers);
+  if(input)input.value='';
+
+  // Insert loading tile
+  const container=document.getElementById('sb-tiles');
+  if(container){
+    const div=document.createElement('div');
+    div.id='sb-tile-'+ticker;
+    div.className='card';
+    div.style.borderLeft='4px solid '+_SB_COLOR;
+    div.style.marginBottom='10px';
+    div.innerHTML='<div style="display:flex;align-items:center;gap:8px;font-family:var(--mono);font-size:12px;color:var(--text2)"><div class="spinner"></div>Loading '+ticker+'...</div>';
+    container.appendChild(div);
+  }
+
+  try{
+    const{snap,hist6mo,distributions,trailingYield}=await _sbFetch(ticker);
+    const html=_sbBuildTile(ticker,snap,hist6mo,distributions,trailingYield,true);
+    const existing=document.getElementById('sb-tile-'+ticker);
+    if(existing){existing.outerHTML=html;}
+    requestAnimationFrame(()=>_sbRenderChart(ticker));
+  }catch(err){
+    const el=document.getElementById('sb-tile-'+ticker);
+    if(el)el.innerHTML=`<div style="font-family:var(--mono);font-size:12px;color:var(--red)">${ticker}: ${err.message}</div>`;
+  }
+}
+
+function sbRemove(ticker){
+  // Remove from persisted list
+  _sbSave(_sbTickers().filter(t=>t!==ticker));
+  // Clear cache
+  S.del('etf_research_'+ticker);
+  // Destroy chart
+  if(window._sbCharts?.[ticker]){window._sbCharts[ticker].destroy();delete window._sbCharts[ticker];}
+  if(window._sbChartData?.[ticker])delete window._sbChartData[ticker];
+  // Remove tile
+  document.getElementById('sb-tile-'+ticker)?.remove();
+  toast(ticker+' removed from sandbox');
+}
+
+function restoreSandboxFromCache(){
+  const tickers=_sbTickers();
+  const container=document.getElementById('sb-tiles');
+  if(!container||!tickers.length)return;
+  container.innerHTML='';
+  tickers.forEach(ticker=>{
+    const c=S.get('etf_research_'+ticker);
+    if(!c)return;
+    const hist6mo=c.hist?{timestamps:c.hist.timestamps.map(d=>new Date(d)),closes:c.hist.closes}:null;
+    const html=_sbBuildTile(ticker,c.snap,hist6mo,c.distributions||[],c.trailingYield,false);
+    const wrap=document.createElement('div');wrap.innerHTML=html;
+    container.appendChild(wrap.firstChild);
+    requestAnimationFrame(()=>_sbRenderChart(ticker));
+  });
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -433,7 +433,7 @@ function showTab(name){
   }
   if(name==='vix'){const vc=document.getElementById('vix-content');if(!vc||vc.querySelector('.empty'))restoreVIXFromCache();}
   if(name==='earnings'){const ec=document.getElementById('earnings-content');if(!ec||ec.querySelector('.empty'))renderEarningsCards();}
-  if(name==='etf'){const etc=document.getElementById('etf-content');if(!etc||etc.querySelector('.empty'))restoreETFFromCache();}
+  if(name==='etf'){const etc=document.getElementById('etf-content');if(!etc||etc.querySelector('.empty'))restoreETFFromCache();restoreSandboxFromCache();}
   if(name==='market'){const mc=document.getElementById('market-content');if(!mc||mc.querySelector('.empty'))restoreMarketFromCache();}
   if(name==='income'){restoreIncomeFromCache();}
 }

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // Version bump this string to force a refresh
 // of the cache when you deploy a new version.
 // ============================================
-const CACHE_NAME = 'putseller-v69';
+const CACHE_NAME = 'putseller-v70';
 
 // Files to cache on install — the app shell
 const APP_SHELL = [


### PR DESCRIPTION
Four files, SW v70, app v3.0.0.
What's new — ETF Research Sandbox:
At the bottom of the ETF tab, below the SPYI and NBOS tiles, a new "🧪 ETF Research Sandbox" section with a text input and "Analyze ETF" button. Type any ticker (GPIQ, YMAX, JEPI, QYLD, etc.) and tap the button to generate a full analysis tile identical in structure to SPYI/NBOS — trailing 12-month yield, price/total return, 52W range, indicated yield, distribution history table, and 6-month price + total return chart.
Key behaviors:

Up to 5 sandbox ETFs simultaneously, stacked vertically for side-by-side comparison
Each tile has an × button to remove it individually (clears tile, cache, and chart)
Ticker list and cached data persist to localStorage under etf_research_TICKER keys — the sandbox survives app restarts and tab switches
restoreSandboxFromCache() is called when the ETF tab opens, restoring all sandbox tiles from cache
The sandbox amber banner on each tile reads "🧪 Research Sandbox — not included in income calculations" — zero bleed into income engine confirmed by verification check